### PR TITLE
Add volume mounts for model directories and settings dir

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,11 @@ services:
     ports:
       - "7860:7860"
     volumes:
+      - "./loras:/app/loras"
       - "./outputs:/app/outputs"
+      - "./.framepack:/app/.framepack"
+      - "./modules/toolbox/model_esrgan:/app/modules/toolbox/model_esrgan"
+      - "./modules/toolbox/model_rife:/app/modules/toolbox/model_rife"
       - "$HOME/.cache/huggingface:/app/hf_download"
     deploy:
       resources:


### PR DESCRIPTION
This allows Docker users to easily drop loras and upscaler/RIFE models into their container through their FP-Sutdio directory. Existing data will be passed through for users migrating to Docker.