### PR TITLE
Unload LLMs on job start

### DIFF
--- a/modules/llm_captioner.py
+++ b/modules/llm_captioner.py
@@ -9,7 +9,7 @@ torch_dtype = torch.float16 if torch.cuda.is_available() else torch.float32
 model = None
 processor = None
 
-def load_captioning_model():
+def _load_captioning_model():
     """Load the Florence-2"""
     global model, processor
     if model is None or processor is None:
@@ -47,23 +47,20 @@ def caption_image(image: np.array):
         image_np (np.ndarray): The input image as a NumPy array (e.g., HxWx3, RGB).
                                 Gradio passes this when type="numpy" is set.
     """
-    load_captioning_model()
-    try:
-        image_pil = Image.fromarray(image)
 
-        inputs = processor(text=prompt, images=image_pil, return_tensors="pt").to(device, torch_dtype)
+    _load_captioning_model()
 
-        generated_ids = model.generate(
-            input_ids=inputs["input_ids"],
-            pixel_values=inputs["pixel_values"],
-            max_new_tokens=1024,
-            num_beams=3,
-            do_sample=False
-        )
-        generated_text = processor.batch_decode(generated_ids, skip_special_tokens=True)[0]
+    image_pil = Image.fromarray(image)
 
+    inputs = processor(text=prompt, images=image_pil, return_tensors="pt").to(device, torch_dtype)
 
-        return generated_text
-    
-    finally:
-        unload_captioning_model()    
+    generated_ids = model.generate(
+        input_ids=inputs["input_ids"],
+        pixel_values=inputs["pixel_values"],
+        max_new_tokens=1024,
+        num_beams=3,
+        do_sample=False
+    )
+    generated_text = processor.batch_decode(generated_ids, skip_special_tokens=True)[0]
+
+    return generated_text

--- a/modules/llm_enhancer.py
+++ b/modules/llm_enhancer.py
@@ -167,14 +167,14 @@ def enhance_prompt(prompt_text: str) -> str:
         # Timestamps found, enhance each section's text
         print(f"LLM Enhancer: Enhancing {len(matches)} sections in a timestamped prompt.")
         enhanced_parts = []
-    
+
         for match in matches:
             # Add the part of the string before the current match (e.g., whitespace)
             enhanced_parts.append(prompt_text[last_end:match.start()])
-                
+
             timestamp_prefix = match.group(1)
             text_to_enhance = match.group(2).strip()
-                
+
             if text_to_enhance:
                 enhanced_text = _run_inference(text_to_enhance)
                 enhanced_parts.append(f"{timestamp_prefix}{enhanced_text}")

--- a/modules/llm_enhancer.py
+++ b/modules/llm_enhancer.py
@@ -167,6 +167,7 @@ def enhance_prompt(prompt_text: str) -> str:
         # Timestamps found, enhance each section's text
         print(f"LLM Enhancer: Enhancing {len(matches)} sections in a timestamped prompt.")
         enhanced_parts = []
+        last_end = 0
 
         for match in matches:
             # Add the part of the string before the current match (e.g., whitespace)

--- a/modules/llm_enhancer.py
+++ b/modules/llm_enhancer.py
@@ -78,7 +78,7 @@ PROMPT_TEMPLATE = (
 model = None
 tokenizer = None
 
-def _load_model():
+def _load_enhancing_model():
     """Loads the model and tokenizer, caching them globally."""
     global model, tokenizer
     if model is None or tokenizer is None:
@@ -93,7 +93,6 @@ def _load_model():
 
 def _run_inference(text_to_enhance: str) -> str:
     """Runs the LLM inference to enhance a single piece of text."""
-    _load_model() # Ensure model is loaded
 
     formatted_prompt = PROMPT_TEMPLATE.format(text_to_enhance=text_to_enhance)
     
@@ -128,6 +127,16 @@ def _run_inference(text_to_enhance: str) -> str:
     response = response.strip().replace('"', '')
     return response
 
+def unload_enhancing_model():
+    global model, tokenizer
+    if model is not None:
+        del model
+        model = None
+    if tokenizer is not None:
+        del tokenizer
+        tokenizer = None
+    torch.cuda.empty_cache()
+
 
 def enhance_prompt(prompt_text: str) -> str:
     """
@@ -139,6 +148,9 @@ def enhance_prompt(prompt_text: str) -> str:
     Returns:
         The enhanced prompt string.
     """
+
+    _load_enhancing_model();
+
     if not prompt_text:
         return ""
 
@@ -155,15 +167,14 @@ def enhance_prompt(prompt_text: str) -> str:
         # Timestamps found, enhance each section's text
         print(f"LLM Enhancer: Enhancing {len(matches)} sections in a timestamped prompt.")
         enhanced_parts = []
-        last_end = 0
-        
+    
         for match in matches:
             # Add the part of the string before the current match (e.g., whitespace)
             enhanced_parts.append(prompt_text[last_end:match.start()])
-            
+                
             timestamp_prefix = match.group(1)
             text_to_enhance = match.group(2).strip()
-            
+                
             if text_to_enhance:
                 enhanced_text = _run_inference(text_to_enhance)
                 enhanced_parts.append(f"{timestamp_prefix}{enhanced_text}")

--- a/modules/pipelines/worker.py
+++ b/modules/pipelines/worker.py
@@ -19,6 +19,8 @@ from modules.prompt_handler import parse_timestamped_prompt
 from modules.generators import create_model_generator
 from modules.pipelines.video_tools import combine_videos_sequentially_from_tensors
 from modules import DUMMY_LORA_NAME # Import the constant
+from modules.llm_captioner import unload_captioning_model
+from modules.llm_enhancer import unload_enhancing_model
 from . import create_pipeline
 
 import __main__ as studio_module # Get a reference to the __main__ module object
@@ -97,6 +99,9 @@ def worker(
     """
 
     random_generator = torch.Generator("cpu").manual_seed(seed)
+
+    unload_enhancing_model()
+    unload_captioning_model()
 
     # Filter out the dummy LoRA from selected_loras at the very beginning of the worker
     actual_selected_loras_for_worker = []


### PR DESCRIPTION
Instead of unloading the captioner right away, leave it loaded until a job starts. Do the same with the enhancer model.