### PR TITLE
Use input image as first frame in Original videos

### DIFF
--- a/modules/generators/original_generator.py
+++ b/modules/generators/original_generator.py
@@ -177,7 +177,7 @@ class OriginalModelGenerator(BaseModelGenerator):
         Returns:
             The number of section latent frames
         """
-        return latent_window_size * 2
+        return (latent_window_size * 2 + 1) if is_last_section else (latent_window_size * 2)
     
     def get_current_pixels(self, real_history_latents, section_latent_frames, vae):
         """

--- a/modules/pipelines/worker.py
+++ b/modules/pipelines/worker.py
@@ -878,6 +878,9 @@ def worker(
             # if magcache is not None and magcache.is_enabled:
             #     print(f"MagCache skipped: {len(magcache.steps_skipped_list)} of {steps} steps: {magcache.steps_skipped_list}")
 
+            if model_type in ("Original", "Original with Endframe") and is_last_section:
+                generated_latents = torch.cat([start_latent.to(generated_latents), generated_latents], dim=2)
+            
             total_generated_latent_frames += int(generated_latents.shape[2])
             # Update history latents using the generator
             history_latents = studio_module.current_generator.update_history_latents(history_latents, generated_latents)


### PR DESCRIPTION
Restores code that prepends the input image as the initial frame for Original videos, and also restores code that adds a +1 to that section's latent frames in order to avoid ghosting.