### PR TITLE
Add .vscode and .gradio to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,9 @@ db.sqlite3-journal
 instance/
 .webassets-cache
 
+# Gradio stuff:
+.gradio/
+
 # Scrapy stuff:
 .scrapy
 
@@ -179,6 +182,9 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
+
+# VS Code
+.vscode/
 
 # Ruff stuff:
 .ruff_cache/


### PR DESCRIPTION
.gradio\certificate.pem - created with --share. @ayan4m1 suggests we ignore the whole directory.

.vscode - users don't want my debug launch settings. ;-)
