### PR TITLE
Cache each Docker CUDA version separately to avoid cache invalidations

### DIFF
--- a/.github/actions/docker-publish-action/action.yml
+++ b/.github/actions/docker-publish-action/action.yml
@@ -57,5 +57,5 @@ runs:
         labels: ${{ steps.meta.outputs.labels }}
         build-args: |
           CUDA_VERSION=${{ inputs.cuda_version }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+        cache-from: type=gha,scope=cu${{ inputs.cuda_version}}
+        cache-to: type=gha,mode=max,scope=cu${{ inputs.cuda_version}}


### PR DESCRIPTION
Right now, each of the three matrix jobs are using the same cache key, so only 12.8 ends up "winning" at the moment. The other two are always misses.

[Relevant docs](https://docs.docker.com/build/cache/backends/gha/#scope)

Add a scope with CUDA version as a variable so that each version has its own cache