### PR TITLE
Disable teacache steps

### DIFF
--- a/modules/interface.py
+++ b/modules/interface.py
@@ -636,7 +636,7 @@ def create_interface(
                                 magcache_max_consecutive_skips_update = gr.update(visible=enable_magcache)
                                 magcache_retention_ratio_update = gr.update(visible=enable_magcache)
 
-                                teacache_num_steps_update = gr.update(visible=enable_teacache)
+                                teacache_num_steps_update = gr.update(visible=False)
                                 teacache_rel_l1_thresh_update = gr.update(visible=enable_teacache)
 
                                 return [

--- a/modules/pipelines/worker.py
+++ b/modules/pipelines/worker.py
@@ -691,7 +691,7 @@ def worker(
             studio_module.current_generator.transformer.install_magcache(magcache)
         elif use_teacache:
             print("Setting Up TeaCache")
-            studio_module.current_generator.transformer.initialize_teacache(enable_teacache=True, num_steps=teacache_num_steps, rel_l1_thresh=teacache_rel_l1_thresh)
+            studio_module.current_generator.transformer.initialize_teacache(enable_teacache=True, num_steps=steps, rel_l1_thresh=teacache_rel_l1_thresh)
             studio_module.current_generator.transformer.uninstall_magcache()
         else:
             print("No Transformer Cache in use")


### PR DESCRIPTION
Minimal change to fix teacache. Always passing the proper number of steps (which must be the number of steps in the generation, not a separate configurable param). And turned the UI param always visible=False.

@colinurbs I left the vestiges. You planned to add some developer parameters (woven through the UI/worker/meta) so maybe easier to turn this into the first, rather than weeding it out entirely?