### PR TITLE
import crop_or_pad_yield_mask from diffusers_helper.utils

### DIFF
--- a/modules/pipelines/worker.py
+++ b/modules/pipelines/worker.py
@@ -50,7 +50,8 @@ def get_cached_or_encode_prompt(
     Stores encoded embeddings (on CPU) in the cache.
     Returns embeddings moved to the target_device.
     """
-    from diffusers_helper.hunyuan import encode_prompt_conds, crop_or_pad_yield_mask
+    from diffusers_helper.hunyuan import encode_prompt_conds
+    from diffusers_helper.utils import crop_or_pad_yield_mask
 
     if prompt in prompt_embedding_cache:
         print(f"Cache hit for prompt: {prompt[:60]}...")


### PR DESCRIPTION
ruff cleanup in 923747a758f11ecee2addf38f5d2ae9879a5688b [removed the unused import](https://github.com/FP-Studio/framepack-studio/commit/923747a758f11ecee2addf38f5d2ae9879a5688b#diff-764ea43c27c89b439ea2454593a3b9828120d422bbe6c6d210d8d79cefce2517L3-L4) of [`crop_or_pad_yield_mask`](https://github.com/FP-Studio/framepack-studio/blob/f4369daf1a9a843de192563bf41fadae05988456/diffusers_helper/utils.py#L477-L489) in [`diffusers_helper.hunyuan`](https://github.com/FP-Studio/framepack-studio/blob/f4369daf1a9a843de192563bf41fadae05988456/diffusers_helper/hunyuan.py#L4).

When the import was removed from diffusers_helper.hunyan that caused the worker to immediately fail all new jobs.

That unused import was actually being depended upon - albeit incorrectly.

This change imports from the correct module.