### PR TITLE
make toolbar disappear on small displays

### DIFF
--- a/modules/ui/styles.css
+++ b/modules/ui/styles.css
@@ -117,6 +117,7 @@
         max-width: 150px;
     }
     #fixed-toolbar {
+        display: none !important; /* Hide entire toolbar on small screens */
         padding: 3px 6px;
         gap: 4px;
     }


### PR DESCRIPTION
make the toolbar disappear on small displays since it covers the tabs (generate, queue, outputs, etc.) on mobile